### PR TITLE
Add DeFiMath to Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 
 ## Libraries
 
+- [DeFiMath](https://github.com/MerkleBlue/defimath) - Gas-optimized Solidity library for DeFi math: Black-Scholes option pricing, Greeks, interest rates, and statistics.
 - [OpenZeppelin Contracts](https://github.com/OpenZeppelin/openzeppelin-contracts) - Library for secure smart contract development.
 
 ## Templates


### PR DESCRIPTION
Adds [DeFiMath](https://github.com/MerkleBlue/defimath) to the Libraries section.

DeFiMath is a pure-Solidity, MIT-licensed library of DeFi math primitives — Black-Scholes option pricing (~2,876 gas, ~4.6× cheaper than next-best on-chain implementation), Greeks, implied-volatility solver, interest-rate math, and statistics. No runtime dependencies.

Inserted alphabetically before `OpenZeppelin Contracts`.